### PR TITLE
kind: split the calls in modules for re-use

### DIFF
--- a/kind/calico/.gitignore
+++ b/kind/calico/.gitignore
@@ -1,0 +1,1 @@
+/calicoctl

--- a/kind/lib/calico.sh
+++ b/kind/lib/calico.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+DIR_LIBS="$(dirname "${BASH_SOURCE[0]}")"
+source "${DIR_LIBS}/kind.sh"
+
+CLUSTER_NAME="netpol-calico"
+CALICO_CLIENT_VERSION="v3.18.1"
+NODE_OPTIONS=(FELIX_IGNORELOOSERPF=true FELIX_XDPENABLED=false)
+MANIFESTS=(https://docs.projectcalico.org/manifests/calico.yaml)
+
+function calico_set_node_options() {
+    ##################################################################
+    # Description:                                                   #
+    #   Set Node Options                                             #
+    ##################################################################
+    for opt in "${NODE_OPTIONS[@]}"; do
+        echo "Setting ${opt} to calico-node..."
+        kubectl -n kube-system set env daemonset/calico-node "${opt}" 1> /dev/null
+        if (( $? )) ; then
+            echo -e "[ \e[1m\e[31mFAIL\e[0m  ] cannot to set ${opt} into the calico node"
+            calico_cleanup_cluster "${CLUSTER_NAME}"
+            exit 1
+        fi
+    done
+}
+
+function calico_apply_manifests() {
+    ##################################################################
+    # Description:                                                   #
+    #   Apply any required manifest to calico                        #
+    ##################################################################
+    echo
+    echo "Applying calico manifest..." 1> /dev/null
+    for manifest in "${MANIFESTS[@]}"; do
+        kubectl apply -f "${manifest}" 1> /dev/null
+        if (( $? )) ; then
+            echo -e "[ \e[1m\e[31mFAIL\e[0m  ] cannot apply ${manifest}"
+            calico_cleanup_cluster "${CLUSTER_NAME}"
+            exit 1
+        fi
+    done
+}
+
+function calico_download_client() {
+    ##################################################################
+    # Description:                                                   #
+    #   Download calicoctl and make the file executable              #
+    ##################################################################
+    echo
+    echo "Downloading calicoctl.."
+    path_calicoctl="${1}"
+    CALICO_CLIENT_VERSION="v3.18.1"
+    curl -L https://github.com/projectcalico/calicoctl/releases/download/"${CALICO_CLIENT_VERSION}"/calicoctl --output "${path_calicoctl}"
+    if (( $? )) ; then
+        echo -e "[ \e[1m\e[31mFAIL\e[0m  ] cannot download calicoctl ${CALICO_VERSION}"
+        exit 1
+    fi
+    chmod +x "${path_calicoctl}"
+}
+
+function calico_cleanup_cluster() {
+    ##################################################################
+    # Description:                                                   #
+    #   cleanup the kind cluster                                     #
+    ##################################################################
+    kind_cleanup_cluster "${CLUSTER_NAME}"
+}
+
+function calico_create_cluster() {
+    ##################################################################
+    # Description:                                                   #
+    #   create the kind cluster                                      #
+    ##################################################################
+    kind_create_cluster "${CLUSTER_NAME}"
+}

--- a/kind/lib/common.sh
+++ b/kind/lib/common.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+function cleanup_cluster() {
+    ##################################################################
+    # Description:                                                   #
+    #   Destroy the kind cluster                                     #
+    #                                                                #
+    # Args:                                                          #
+    #     ${1} = cluster name                                        #
+    ##################################################################
+    cluster_name="{$1}"
+    kind delete cluster --name "${cluster_name}"
+} 
+
+function wait_all_pods_status_running() {
+    ##################################################################
+    # Description:                                                   #
+    #   Wait all pods in the cluster be in running status            #
+    #                                                                #
+    # Args:                                                          #
+    #     ${1} = seconds to be used to wait until the next kubectl   #
+    #            command                                             #
+    ##################################################################
+    sleep_sec="${1}"
+    while true ; do
+        cmd=$(kubectl get pods -A --field-selector=status.phase!=Running -o name)
+        if [ -z "${cmd}" ];
+        then
+           break
+        fi
+        echo
+        numberpods=$(echo "${cmd}" | wc -l)
+        echo -e "[\e[1m\e[32m$(date +"%r")\e[0m] The following \e[1m\e[32m${numberpods} pods are NOT in RUNNING status yet\e[0m... please wait $sleep_sec seconds for a auto-refresh.."
+        echo -e "${cmd}"
+        sleep "${sleep_sec}"
+    done
+}

--- a/kind/lib/kind.sh
+++ b/kind/lib/kind.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+function kind_create_cluster() {
+    ##################################################################
+    # Description:                                                   #
+    #   Create cluster via kind                                      #
+    ##################################################################
+
+    cluster_name="${1}"
+    conf="${2}"
+
+    kind create cluster --name "${cluster_name}" --config "${conf}"
+    if (( $? )) ; then
+        echo -e "[ \e[1m\e[31mFAIL\e[0m  ] cannot create cluster ${cluster_name} ${conf}"
+        exit 1
+    fi
+
+    until kubectl cluster-info;  do
+        echo "$(date)waiting for cluster..."
+        sleep 2
+    done
+}
+
+
+function kind_cleanup_cluster() {
+    ##################################################################
+    # Description:                                                   #
+    #   cleanup the kind cluster                                     #
+    ##################################################################
+
+    cluster_name="${1}"
+
+    echo "Cleanup cluster ${cluster_name}..."
+    kind delete cluster --name "${cluster_name}"
+    if (( $? )) ; then
+        echo -e "[ \e[1m\e[31mFAIL\e[0m  ] cannot cleanup cluster ${cluster_name}"
+        exit 1
+    fi
+}


### PR DESCRIPTION
Instead of duplicating code, let's re-use calls to
simplify creating new network policies tests.

Signed-off-by: Douglas Schilling Landgraf <dougsland@gmail.com>