### PR TITLE
log server version

### DIFF
--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/mattfenwick/cyclonus/pkg/connectivity"
 	"github.com/mattfenwick/cyclonus/pkg/connectivity/probe"
@@ -81,9 +82,14 @@ func RunGenerateCommand(args *GenerateArgs) {
 	if args.Mock {
 		kubernetes = kube.NewMockKubernetes(1.0)
 	} else {
-		kubernetes, err = kube.NewKubernetesForContext(args.Context)
+		kubeClient, err := kube.NewKubernetesForContext(args.Context)
+		info, err := kubeClient.ClientSet.ServerVersion()
+		utils.DoOrDie(err)
+		jsonBytes, err := json.MarshalIndent(info, "", "  ")
+		utils.DoOrDie(err)
+		fmt.Printf("server version: \n%s\n", jsonBytes)
+		kubernetes = kubeClient
 	}
-	utils.DoOrDie(err)
 
 	serverProtocols := parseProtocols(args.ServerProtocols)
 

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/mattfenwick/cyclonus/pkg/connectivity"
 	"github.com/mattfenwick/cyclonus/pkg/connectivity/probe"
@@ -85,9 +84,7 @@ func RunGenerateCommand(args *GenerateArgs) {
 		kubeClient, err := kube.NewKubernetesForContext(args.Context)
 		info, err := kubeClient.ClientSet.ServerVersion()
 		utils.DoOrDie(err)
-		jsonBytes, err := json.MarshalIndent(info, "", "  ")
-		utils.DoOrDie(err)
-		fmt.Printf("server version: \n%s\n", jsonBytes)
+		fmt.Printf("Kubernetes server version: \n%s\n", utils.JsonString(info))
 		kubernetes = kubeClient
 	}
 

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"github.com/mattfenwick/cyclonus/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -25,5 +26,9 @@ func SetupVersionCommand() *cobra.Command {
 }
 
 func RunVersionCommand() {
-	fmt.Printf("Version: %s\nGit SHA: %s\nBuild time: %s\n", version, gitSHA, buildTime)
+	fmt.Printf("Cyclonus version: \n%s\n", utils.JsonString(map[string]string{
+		"Version":   version,
+		"GitSHA":    gitSHA,
+		"BuildTime": buildTime,
+	}))
 }


### PR DESCRIPTION
To help with debugging future problems.

Example:

```
go run cmd/cyclonus/main.go generate                          
INFO[2021-04-10T07:03:33-04:00] log level set to 'info'                      
Cyclonus version: 
{
  "BuildTime": "development",
  "GitSHA": "development",
  "Version": "development"
}
Kubernetes server version: 
{
  "major": "1",
  "minor": "20",
  "gitVersion": "v1.20.2",
  "gitCommit": "faecb196815e248d3ecfb03c680a4507229c2a56",
  "gitTreeState": "clean",
  "buildDate": "2021-01-21T01:11:42Z",
  "goVersion": "go1.15.5",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```