### PR TITLE
handle new default namespace label without crashing

### DIFF
--- a/pkg/connectivity/probe/resource-printer.go
+++ b/pkg/connectivity/probe/resource-printer.go
@@ -35,13 +35,15 @@ func (r *Resources) RenderTable() string {
 	})
 	for _, ns := range nsSlice {
 		labels := r.Namespaces[ns]
+		nsLabelLines := labelsToLines(labels)
 		for _, pod := range nsToPod[ns] {
+			podLabelLines := labelsToLines(pod.Labels)
 			for _, cont := range pod.Containers {
 				table.Append([]string{
 					ns,
-					labelsToLines(labels),
+					nsLabelLines,
 					pod.Name,
-					labelsToLines(pod.Labels),
+					podLabelLines,
 					fmt.Sprintf("pod: %s\nservice: %s", pod.IP, pod.ServiceIP),
 					fmt.Sprintf("%s, port %s: %d on %s", cont.Name, cont.PortName, cont.Port, cont.Protocol),
 				})
@@ -54,9 +56,14 @@ func (r *Resources) RenderTable() string {
 }
 
 func labelsToLines(labels map[string]string) string {
+	var keys []string
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
 	var lines []string
-	for k, v := range labels {
-		lines = append(lines, fmt.Sprintf("%s: %s", k, v))
+	for _, key := range keys {
+		lines = append(lines, fmt.Sprintf("%s: %s", key, labels[key]))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/pkg/connectivity/suite_test.go
+++ b/pkg/connectivity/suite_test.go
@@ -1,0 +1,14 @@
+package connectivity
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestConnectivity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunTestCaseStateTests()
+	RunSpecs(t, "connectivity suite")
+}

--- a/pkg/connectivity/testcasestate.go
+++ b/pkg/connectivity/testcasestate.go
@@ -191,31 +191,31 @@ func (t *TestCaseState) verifyClusterStateHelper() error {
 		actualPods[probe.NewPodString(kubePod.Namespace, kubePod.Name).String()] = kubePod
 	}
 	// are we missing any pods?
-	for _, pod := range t.Resources.Pods {
-		if actualPod, ok := actualPods[pod.PodString().String()]; ok {
-			if !areLabelsEqual(actualPod.Labels, pod.Labels) {
-				return errors.Errorf("for pod %s, expected labels %+v (found %+v)", pod.PodString().String(), pod.Labels, actualPod.Labels)
+	for _, expectedPod := range t.Resources.Pods {
+		if actualPod, ok := actualPods[expectedPod.PodString().String()]; ok {
+			if !NewLabelsDiff(actualPod.Labels, expectedPod.Labels).AreLabelsEqual() {
+				return errors.Errorf("for pod %s, expected labels %+v (found %+v)", expectedPod.PodString().String(), expectedPod.Labels, actualPod.Labels)
 			}
-			if actualPod.Status.PodIP != pod.IP {
-				return errors.Errorf("for pod %s, expected ip %s (found %s)", pod.PodString().String(), pod.IP, actualPod.Status.PodIP)
+			if actualPod.Status.PodIP != expectedPod.IP {
+				return errors.Errorf("for pod %s, expected ip %s (found %s)", expectedPod.PodString().String(), expectedPod.IP, actualPod.Status.PodIP)
 			}
-			if !pod.IsEqualToKubePod(actualPod) {
-				return errors.Errorf("for pod %s, expected containers %+v (found %+v)", pod.PodString().String(), pod.Containers, actualPod.Spec.Containers)
+			if !expectedPod.IsEqualToKubePod(actualPod) {
+				return errors.Errorf("for pod %s, expected containers %+v (found %+v)", expectedPod.PodString().String(), expectedPod.Containers, actualPod.Spec.Containers)
 			}
 		} else {
-			return errors.Errorf("missing expected pod %s", pod.PodString().String())
+			return errors.Errorf("missing expected pod %s", expectedPod.PodString().String())
 		}
 	}
 
 	// 2. services: selectors, ports
-	for _, pod := range t.Resources.Pods {
-		expected := pod.KubeService()
+	for _, expectedPod := range t.Resources.Pods {
+		expected := expectedPod.KubeService()
 		svc, err := t.Kubernetes.GetService(expected.Namespace, expected.Name)
 		if err != nil {
 			return err
 		}
-		if !areLabelsEqual(svc.Spec.Selector, pod.Labels) {
-			return errors.Errorf("for service %s/%s, expected labels %+v (found %+v)", pod.Namespace, pod.Name, pod.Labels, svc.Spec.Selector)
+		if !NewLabelsDiff(svc.Spec.Selector, expectedPod.Labels).AreLabelsEqual() {
+			return errors.Errorf("for service %s/%s, expected labels %+v (found %+v)", expectedPod.Namespace, expectedPod.Name, expectedPod.Labels, svc.Spec.Selector)
 		}
 		if len(expected.Spec.Ports) != len(svc.Spec.Ports) {
 			return errors.Errorf("for service %s/%s, expected %d ports (found %d)", expected.Namespace, expected.Name, len(expected.Spec.Ports), len(svc.Spec.Ports))
@@ -229,13 +229,13 @@ func (t *TestCaseState) verifyClusterStateHelper() error {
 	}
 
 	// 3. namespaces: names, labels
-	for ns, labels := range t.Resources.Namespaces {
+	for ns, expectedNamespaceLabels := range t.Resources.Namespaces {
 		namespace, err := t.Kubernetes.GetNamespace(ns)
 		if err != nil {
 			return err
 		}
-		if !areLabelsEqual(namespace.Labels, labels) {
-			return errors.Errorf("for namespace %s, expected labels %+v (found %+v)", ns, labels, namespace.Labels)
+		if !NewLabelsDiff(namespace.Labels, expectedNamespaceLabels).AreLabelsEqual() {
+			return errors.Errorf("for namespace %s, expected labels %+v (found %+v)", ns, expectedNamespaceLabels, namespace.Labels)
 		}
 	}
 
@@ -243,17 +243,40 @@ func (t *TestCaseState) verifyClusterStateHelper() error {
 	return nil
 }
 
-func areLabelsEqual(l map[string]string, r map[string]string) bool {
-	if len(l) != len(r) {
-		return false
+type LabelsDiff struct {
+	Same      []string
+	Different []string
+	Extra     []string
+	Missing   []string
+}
+
+func NewLabelsDiff(actual map[string]string, expected map[string]string) *LabelsDiff {
+	ld := &LabelsDiff{
+		Same:      nil,
+		Different: nil,
+		Extra:     nil,
+		Missing:   nil,
 	}
-	for k, lv := range l {
-		rv, ok := r[k]
-		if !ok || lv != rv {
-			return false
+	for k, actualValue := range actual {
+		expectedValue, ok := expected[k]
+		if !ok {
+			ld.Extra = append(ld.Extra, k)
+		} else if actualValue != expectedValue {
+			ld.Different = append(ld.Different, k)
+		} else {
+			ld.Same = append(ld.Same, k)
 		}
 	}
-	return true
+	for k, _ := range expected {
+		if _, ok := actual[k]; !ok {
+			ld.Missing = append(ld.Missing, k)
+		}
+	}
+	return ld
+}
+
+func (ld *LabelsDiff) AreLabelsEqual() bool {
+	return len(ld.Different) == 0 && len(ld.Extra) == 0 && len(ld.Missing) == 0
 }
 
 func (t *TestCaseState) resetLabelsInKubeHelper() error {

--- a/pkg/connectivity/testcasestate_tests.go
+++ b/pkg/connectivity/testcasestate_tests.go
@@ -1,0 +1,106 @@
+package connectivity
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type buildLabelDiffCase struct {
+	actual   map[string]string
+	expected map[string]string
+	diff     *LabelsDiff
+}
+
+type labelDiffMethodsCase struct {
+	diff                        *LabelsDiff
+	areLabelsEqual              bool
+	areAllExpectedLabelsPresent bool
+}
+
+func RunTestCaseStateTests() {
+	Describe("LabelDiff", func() {
+		empty := map[string]string{}
+		ab := map[string]string{"a": "b"}
+		ac := map[string]string{"a": "c"}
+
+		It("Build LabelDiff", func() {
+			testCases := []*buildLabelDiffCase{
+				{
+					actual:   empty,
+					expected: empty,
+					diff:     &LabelsDiff{},
+				},
+				{
+					actual:   empty,
+					expected: ab,
+					diff:     &LabelsDiff{Missing: []string{"a"}},
+				},
+				{
+					actual:   ab,
+					expected: empty,
+					diff:     &LabelsDiff{Extra: []string{"a"}},
+				},
+				{
+					actual:   ab,
+					expected: ab,
+					diff:     &LabelsDiff{Same: []string{"a"}},
+				},
+				{
+					actual:   ab,
+					expected: ac,
+					diff:     &LabelsDiff{Different: []string{"a"}},
+				},
+				{
+					actual:   ac,
+					expected: ab,
+					diff:     &LabelsDiff{Different: []string{"a"}},
+				},
+				{
+					actual:   map[string]string{"a": "b", "c": "d"},
+					expected: map[string]string{"c": "e", "a": "b"},
+					diff:     &LabelsDiff{Same: []string{"a"}, Different: []string{"c"}},
+				},
+			}
+			for _, tc := range testCases {
+				diff := NewLabelsDiff(tc.actual, tc.expected)
+				Expect(diff).To(Equal(tc.diff))
+			}
+		})
+
+		It("Call LabelDiff methods", func() {
+			testCases := []*labelDiffMethodsCase{
+				{
+					diff:                        &LabelsDiff{},
+					areLabelsEqual:              true,
+					areAllExpectedLabelsPresent: true,
+				},
+				{
+					diff:                        &LabelsDiff{Same: []string{"c", "e"}},
+					areLabelsEqual:              true,
+					areAllExpectedLabelsPresent: true,
+				},
+				{
+					diff:                        &LabelsDiff{Different: []string{"q"}},
+					areLabelsEqual:              false,
+					areAllExpectedLabelsPresent: false,
+				},
+				{
+					diff:                        &LabelsDiff{Missing: []string{"z"}},
+					areLabelsEqual:              false,
+					areAllExpectedLabelsPresent: false,
+				},
+				{
+					diff:                        &LabelsDiff{Extra: []string{"y"}},
+					areLabelsEqual:              false,
+					areAllExpectedLabelsPresent: true,
+				},
+			}
+			for _, tc := range testCases {
+				fmt.Printf("test case: %t, %t, %+v\n", tc.areLabelsEqual, tc.areAllExpectedLabelsPresent, tc.diff)
+				Expect(tc.areLabelsEqual).To(Equal(tc.diff.AreLabelsEqual()))
+				Expect(tc.areAllExpectedLabelsPresent).To(Equal(tc.diff.AreAllExpectedLabelsPresent()))
+			}
+		})
+	})
+}


### PR DESCRIPTION
Hypothesis: this affects kube 1.21 and above.

For now, we'll allow extra labels and just log warnings if any are detected.  In the future, let's handle this correctly.  See #91 
