### PR TITLE
fix port simplification test case

### DIFF
--- a/pkg/matcher/simplifier.go
+++ b/pkg/matcher/simplifier.go
@@ -1,8 +1,10 @@
 package matcher
 
 import (
+	"github.com/mattfenwick/collections/pkg/json"
 	"github.com/mattfenwick/collections/pkg/slice"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 )
 
@@ -35,6 +37,7 @@ func Simplify(matchers []PeerMatcher) []PeerMatcher {
 }
 
 func simplifyPortsForAllPeers(matchers []*PortsForAllPeersMatcher) *PortsForAllPeersMatcher {
+	logrus.Debugf("simplifyPortsForAllPeers:\n%s\n", json.MustMarshalToString(matchers))
 	if len(matchers) == 0 {
 		return nil
 	}


### PR DESCRIPTION
This caused an exponential explosion in explanation of netpols with multiple port matchers, for example:

```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: pol4
  namespace: ns-z
spec:
  egress:
  - ports:
    - port: 53
      protocol: UDP
    - port: 53
      protocol: TCP
  - ports:
    - port: 100
      protocol: TCP
    - port: 100
      protocol: UDP
```