### PR TITLE
Add option to specify image repository for pulling agnhost image

### DIFF
--- a/cmd/worker/Dockerfile
+++ b/cmd/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM k8s.gcr.io/e2e-test-images/agnhost:2.43
+FROM registry.k8s.io/e2e-test-images/agnhost:2.43
 
 ENTRYPOINT ["/worker"]
 

--- a/docs/test-runs.md
+++ b/docs/test-runs.md
@@ -24,7 +24,7 @@ namespace x).  There are three modes to test network policies in:
 
 Tests can run over multiple protocols and ports.  A typical test run includes protocols TCP and UDP (often
 SCTP as well), and ports 80 and 81.  Each port/protocol combination is served by a container running `agnhost` (docker
-image: k8s.gcr.io/e2e-test-images/agnhost) which is capable of serving a specific protocol on a specific port.  Thus,
+image: registry.k8s.io/e2e-test-images/agnhost) which is capable of serving a specific protocol on a specific port.  Thus,
 if your test includes protocols TCP and UDP, and ports 80 and 81, each pod will have 4 containers.  Named ports are
 included as well -- `serve-80-udp` is the name for port 80 on UDP.
 

--- a/hack/kind/run-cyclonus.sh
+++ b/hack/kind/run-cyclonus.sh
@@ -27,8 +27,8 @@ pushd "$CNI"
 popd
 
 # preload agnhost image
-docker pull k8s.gcr.io/e2e-test-images/agnhost:2.43
-kind load docker-image k8s.gcr.io/e2e-test-images/agnhost:2.43 --name "$CLUSTER_NAME"
+docker pull registry.k8s.io/e2e-test-images/agnhost:2.43
+kind load docker-image registry.k8s.io/e2e-test-images/agnhost:2.43 --name "$CLUSTER_NAME"
 
 # make sure that the new kind cluster is the current kubectl context
 kind get clusters

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -44,6 +44,7 @@ type GenerateArgs struct {
 	DryRun                    bool
 	JobTimeoutSeconds         int
 	JunitResultsFile          string
+	ImageRepository           string
 	//BatchJobs                 bool
 }
 
@@ -85,6 +86,7 @@ func SetupGenerateCommand() *cobra.Command {
 	command.Flags().BoolVar(&args.DryRun, "dry-run", false, "if true, don't actually do anything: just print out what would be done")
 
 	command.Flags().StringVar(&args.JunitResultsFile, "junit-results-file", "", "output junit results to the specified file")
+	command.Flags().StringVar(&args.ImageRepository, "image-repository", "registry.k8s.io", "Image repository for agnhost")
 
 	return command
 }
@@ -113,7 +115,7 @@ func RunGenerateCommand(args *GenerateArgs) {
 	serverProtocols := parseProtocols(args.ServerProtocols)
 
 	batchJobs := false // args.BatchJobs
-	resources, err := probe.NewDefaultResources(kubernetes, args.ServerNamespaces, args.ServerPods, args.ServerPorts, serverProtocols, externalIPs, args.PodCreationTimeoutSeconds, batchJobs)
+	resources, err := probe.NewDefaultResources(kubernetes, args.ServerNamespaces, args.ServerPods, args.ServerPorts, serverProtocols, externalIPs, args.PodCreationTimeoutSeconds, batchJobs, args.ImageRepository)
 	utils.DoOrDie(err)
 
 	interpreterConfig := &connectivity.InterpreterConfig{

--- a/pkg/cli/generate.go
+++ b/pkg/cli/generate.go
@@ -44,7 +44,7 @@ type GenerateArgs struct {
 	DryRun                    bool
 	JobTimeoutSeconds         int
 	JunitResultsFile          string
-	ImageRepository           string
+	ImageRegistry             string
 	//BatchJobs                 bool
 }
 
@@ -86,7 +86,7 @@ func SetupGenerateCommand() *cobra.Command {
 	command.Flags().BoolVar(&args.DryRun, "dry-run", false, "if true, don't actually do anything: just print out what would be done")
 
 	command.Flags().StringVar(&args.JunitResultsFile, "junit-results-file", "", "output junit results to the specified file")
-	command.Flags().StringVar(&args.ImageRepository, "image-repository", "registry.k8s.io", "Image repository for agnhost")
+	command.Flags().StringVar(&args.ImageRegistry, "image-registry", "registry.k8s.io", "Image registry for agnhost")
 
 	return command
 }
@@ -115,7 +115,7 @@ func RunGenerateCommand(args *GenerateArgs) {
 	serverProtocols := parseProtocols(args.ServerProtocols)
 
 	batchJobs := false // args.BatchJobs
-	resources, err := probe.NewDefaultResources(kubernetes, args.ServerNamespaces, args.ServerPods, args.ServerPorts, serverProtocols, externalIPs, args.PodCreationTimeoutSeconds, batchJobs, args.ImageRepository)
+	resources, err := probe.NewDefaultResources(kubernetes, args.ServerNamespaces, args.ServerPods, args.ServerPorts, serverProtocols, externalIPs, args.PodCreationTimeoutSeconds, batchJobs, args.ImageRegistry)
 	utils.DoOrDie(err)
 
 	interpreterConfig := &connectivity.InterpreterConfig{

--- a/pkg/cli/probe.go
+++ b/pkg/cli/probe.go
@@ -35,7 +35,7 @@ type ProbeArgs struct {
 	ServerPorts      []int
 	ServerNamespaces []string
 	ServerPods       []string
-	ImageRepository  string
+	ImageRegistry    string
 }
 
 func SetupProbeCommand() *cobra.Command {
@@ -68,7 +68,7 @@ func SetupProbeCommand() *cobra.Command {
 	command.Flags().IntVar(&args.PerturbationWaitSeconds, "perturbation-wait-seconds", 5, "number of seconds to wait after perturbing the cluster (i.e. create a network policy, modify a ns/pod label) before running probes, to give the CNI time to update the cluster state")
 	command.Flags().IntVar(&args.PodCreationTimeoutSeconds, "pod-creation-timeout-seconds", 60, "number of seconds to wait for pods to create, be running and have IP addresses")
 	command.Flags().StringVar(&args.PolicyPath, "policy-path", "", "path to yaml network policy to create in kube; if empty, will not create any policies")
-	command.Flags().StringVar(&args.ImageRepository, "image-repository", "registry.k8s.io", "Image repository for agnhost")
+	command.Flags().StringVar(&args.ImageRegistry, "image-registry", "registry.k8s.io", "Image registry for agnhost")
 
 	return command
 }
@@ -85,7 +85,7 @@ func RunProbeCommand(args *ProbeArgs) {
 	protocols := parseProtocols(args.Protocols)
 	serverProtocols := parseProtocols(args.ServerProtocols)
 
-	resources, err := probe.NewDefaultResources(kubernetes, args.ServerNamespaces, args.ServerPods, args.ServerPorts, serverProtocols, externalIPs, args.PodCreationTimeoutSeconds, false, args.ImageRepository)
+	resources, err := probe.NewDefaultResources(kubernetes, args.ServerNamespaces, args.ServerPods, args.ServerPorts, serverProtocols, externalIPs, args.PodCreationTimeoutSeconds, false, args.ImageRegistry)
 	utils.DoOrDie(err)
 
 	interpreterConfig := &connectivity.InterpreterConfig{

--- a/pkg/connectivity/probe/pod.go
+++ b/pkg/connectivity/probe/pod.go
@@ -27,11 +27,11 @@ func NewPod(ns string, name string, labels map[string]string, ip string, contain
 	}
 }
 
-func NewDefaultPod(ns string, name string, ports []int, protocols []v1.Protocol, batchJobs bool, imageRepository string) *Pod {
+func NewDefaultPod(ns string, name string, ports []int, protocols []v1.Protocol, batchJobs bool, imageRegistry string) *Pod {
 	var containers []*Container
 	for _, port := range ports {
 		for _, protocol := range protocols {
-			containers = append(containers, NewDefaultContainer(port, protocol, batchJobs, imageRepository))
+			containers = append(containers, NewDefaultContainer(port, protocol, batchJobs, imageRegistry))
 		}
 	}
 	return &Pod{
@@ -164,22 +164,22 @@ func (p *Pod) PodString() PodString {
 }
 
 type Container struct {
-	Name            string
-	Port            int
-	Protocol        v1.Protocol
-	PortName        string
-	BatchJobs       bool
-	imageRepository string
+	Name          string
+	Port          int
+	Protocol      v1.Protocol
+	PortName      string
+	BatchJobs     bool
+	ImageRegistry string
 }
 
-func NewDefaultContainer(port int, protocol v1.Protocol, batchJobs bool, imageRepository string) *Container {
+func NewDefaultContainer(port int, protocol v1.Protocol, batchJobs bool, imageRegistry string) *Container {
 	return &Container{
-		Name:            fmt.Sprintf("cont-%d-%s", port, strings.ToLower(string(protocol))),
-		Port:            port,
-		Protocol:        protocol,
-		PortName:        fmt.Sprintf("serve-%d-%s", port, strings.ToLower(string(protocol))),
-		BatchJobs:       batchJobs,
-		imageRepository: imageRepository,
+		Name:          fmt.Sprintf("cont-%d-%s", port, strings.ToLower(string(protocol))),
+		Port:          port,
+		Protocol:      protocol,
+		PortName:      fmt.Sprintf("serve-%d-%s", port, strings.ToLower(string(protocol))),
+		BatchJobs:     batchJobs,
+		ImageRegistry: imageRegistry,
 	}
 }
 
@@ -195,7 +195,7 @@ func (c *Container) Image() string {
 	if c.BatchJobs {
 		return cyclonusWorkerImage
 	}
-	return c.imageRepository + "/" + agnhostImage
+	return c.ImageRegistry + "/" + agnhostImage
 }
 
 func (c *Container) KubeContainer() v1.Container {

--- a/pkg/connectivity/probe/resources.go
+++ b/pkg/connectivity/probe/resources.go
@@ -1,6 +1,8 @@
 package probe
 
 import (
+	"time"
+
 	"github.com/mattfenwick/collections/pkg/slice"
 	"github.com/mattfenwick/cyclonus/pkg/kube"
 	"github.com/pkg/errors"
@@ -8,7 +10,6 @@ import (
 	"golang.org/x/exp/maps"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 type Resources struct {
@@ -17,7 +18,7 @@ type Resources struct {
 	//ExternalIPs []string
 }
 
-func NewDefaultResources(kubernetes kube.IKubernetes, namespaces []string, podNames []string, ports []int, protocols []v1.Protocol, externalIPs []string, podCreationTimeoutSeconds int, batchJobs bool) (*Resources, error) {
+func NewDefaultResources(kubernetes kube.IKubernetes, namespaces []string, podNames []string, ports []int, protocols []v1.Protocol, externalIPs []string, podCreationTimeoutSeconds int, batchJobs bool, imageRepository string) (*Resources, error) {
 	//sort.Strings(externalIPs) // TODO why is this here?
 
 	r := &Resources{
@@ -27,7 +28,7 @@ func NewDefaultResources(kubernetes kube.IKubernetes, namespaces []string, podNa
 
 	for _, ns := range namespaces {
 		for _, podName := range podNames {
-			r.Pods = append(r.Pods, NewDefaultPod(ns, podName, ports, protocols, batchJobs))
+			r.Pods = append(r.Pods, NewDefaultPod(ns, podName, ports, protocols, batchJobs, imageRepository))
 		}
 		r.Namespaces[ns] = map[string]string{"ns": ns}
 	}

--- a/pkg/connectivity/probe/resources.go
+++ b/pkg/connectivity/probe/resources.go
@@ -18,7 +18,7 @@ type Resources struct {
 	//ExternalIPs []string
 }
 
-func NewDefaultResources(kubernetes kube.IKubernetes, namespaces []string, podNames []string, ports []int, protocols []v1.Protocol, externalIPs []string, podCreationTimeoutSeconds int, batchJobs bool, imageRepository string) (*Resources, error) {
+func NewDefaultResources(kubernetes kube.IKubernetes, namespaces []string, podNames []string, ports []int, protocols []v1.Protocol, externalIPs []string, podCreationTimeoutSeconds int, batchJobs bool, imageRegistry string) (*Resources, error) {
 	//sort.Strings(externalIPs) // TODO why is this here?
 
 	r := &Resources{
@@ -28,7 +28,7 @@ func NewDefaultResources(kubernetes kube.IKubernetes, namespaces []string, podNa
 
 	for _, ns := range namespaces {
 		for _, podName := range podNames {
-			r.Pods = append(r.Pods, NewDefaultPod(ns, podName, ports, protocols, batchJobs, imageRepository))
+			r.Pods = append(r.Pods, NewDefaultPod(ns, podName, ports, protocols, batchJobs, imageRegistry))
 		}
 		r.Namespaces[ns] = map[string]string{"ns": ns}
 	}


### PR DESCRIPTION
This adds an option to specify the image repository. Sometimes we run tests in region where access to public repositories is blocked. The default value is updated to `registry.k8s.io` instead of `k8s.gcr.io`  as per this [article](https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/)
